### PR TITLE
chore: Update build and test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,21 +36,29 @@ jobs:
 
   build_and_test:
     name: build and test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         toolchain:
           - stable
           - beta
           - nightly
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
-      # Exclude the test that requires the clipboard.
+      # Exclude the test that requires the clipboard on ubuntu-latest.
       # Using xvfb-run allows copying to the clipboard,
       # but reading from the clipboard fails, causing the test to fail.
-      - run: cargo test --verbose -- --skip 'tests::output_passwords_to_clipboard'
+      - if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run cargo test --verbose -- --skip 'tests::output_passwords_to_clipboard'
+      # All tests are executed on windows-latest and macos-latest as clipboard is available.
+      - if: matrix.os != 'ubuntu-latest'
+        run: cargo test --verbose
 
   msrv:
     name: msrv
@@ -61,3 +69,11 @@ jobs:
     - run: |
         rustup update
         cargo hack check --rust-version --workspace --all-targets --ignore-private
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo install cargo-release
+      - run: cargo release --dry-run


### PR DESCRIPTION
- Add support for multiple operating systems in the build_and_test job
- Run all tests on windows-latest and macos-latest
- Add release job to automate the release process